### PR TITLE
Finish Espresso tests for Add Item Fragment and Added some Espresso Helper Functions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,7 +92,7 @@ jobs:
           EMULATOR_TIMEOUT=$EMULATOR_TIMEOUT EMULATOR_NAME=$EMULATOR_NAME ./start_emu_headless.sh
   
       - name: Run tests
-        run: ./gradlew connectedAndroidTest --build-cache --debug
+        run: ./gradlew connectedAndroidTest -info --build-cache
 
       - name: Stop emulator
         run: adb emu kill

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ env:
   ANDROID_BUILD_TOOLS_VERSION: 34.0.0
   ANDROID_SDK_PACKAGES: system-images;android-34;default;x86_64 platforms;android-34 build-tools;34.0.0 platform-tools emulator
   EMULATOR_TIMEOUT: 350
-  EMULATOR_NAME: nexus
+  EMULATOR_NAME: pixel
 
 jobs:
   buildUnitTest:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,7 +92,7 @@ jobs:
           EMULATOR_TIMEOUT=$EMULATOR_TIMEOUT EMULATOR_NAME=$EMULATOR_NAME ./start_emu_headless.sh
   
       - name: Run tests
-        run: ./gradlew connectedAndroidTest -info --build-cache
+        run: ./gradlew connectedAndroidTest --stacktrace --build-cache
 
       - name: Stop emulator
         run: adb emu kill

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,7 +92,7 @@ jobs:
           EMULATOR_TIMEOUT=$EMULATOR_TIMEOUT EMULATOR_NAME=$EMULATOR_NAME ./start_emu_headless.sh
   
       - name: Run tests
-        run: ./gradlew connectedAndroidTest --info
-  
+        run: ./gradlew connectedAndroidTest --build-cache --debug
+
       - name: Stop emulator
         run: adb emu kill

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ env:
   ANDROID_BUILD_TOOLS_VERSION: 34.0.0
   ANDROID_SDK_PACKAGES: system-images;android-34;default;x86_64 platforms;android-34 build-tools;34.0.0 platform-tools emulator
   EMULATOR_TIMEOUT: 350
-  EMULATOR_NAME: pixel
+  EMULATOR_NAME: pixel-3a
 
 jobs:
   buildUnitTest:
@@ -92,7 +92,7 @@ jobs:
           EMULATOR_TIMEOUT=$EMULATOR_TIMEOUT EMULATOR_NAME=$EMULATOR_NAME ./start_emu_headless.sh
   
       - name: Run tests
-        run: ./gradlew connectedAndroidTest --stacktrace --build-cache
+        run: ./gradlew connectedAndroidTest -info --build-cache
 
       - name: Stop emulator
         run: adb emu kill

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,7 +92,7 @@ jobs:
           EMULATOR_TIMEOUT=$EMULATOR_TIMEOUT EMULATOR_NAME=$EMULATOR_NAME ./start_emu_headless.sh
   
       - name: Run tests
-        run: ./gradlew connectedAndroidTest
+        run: ./gradlew connectedAndroidTest --info
   
       - name: Stop emulator
         run: adb emu kill

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -59,6 +59,7 @@ public class AddItemFragmentTest extends TestSetup {
         enterText(R.id.add_item_model, "MyModel");
         enterText(R.id.add_item_serial_number, "1234567890");
         onView(withId(R.id.add_item_comment)).perform(scrollTo());
+        waitForView(withId(R.id.add_item_comment));
         enterText(R.id.add_item_comment, "this is a comment");
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -46,7 +46,7 @@ public class AddItemFragmentTest extends TestSetup {
     }
 
     @Test
-    public void testAddItemWithValidData() {
+    public void testAddItemWithNewUser() {
         // Add acquisition date
         String acquisitionDate = selectFirstDayOfMonth();
         // Add required description and estimated cost

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -19,9 +19,8 @@ import com.example.househomey.testUtils.TestSetup;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 public class AddItemFragmentTest extends TestSetup {
     @Before
@@ -29,42 +28,49 @@ public class AddItemFragmentTest extends TestSetup {
         onView(withId(R.id.action_add)).perform(click());
     }
 
-    public void selectFirstDayOfMonth() {
-        // Open date picker
+    public String selectFirstDayOfMonth() {
         onView(withId(R.id.add_item_date)).perform(click());
-        // Get the first day of this month
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(Calendar.DAY_OF_MONTH, 1);
-        Date firstDayOfMonth = calendar.getTime();
-        // Format the date to match the MaterialDatePicker content description format
-        SimpleDateFormat dateFormat = new SimpleDateFormat("EEEE, MMMM d");
-        String formattedDate = dateFormat.format(firstDayOfMonth);
+        // Get the first day of the month matching MaterialDatePicker content description format
+        LocalDate currentDate = LocalDate.now().withDayOfMonth(1);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("EEEE, MMMM d");
+        String formattedDate = currentDate.format(dateFormat);
         // Select the day and click confirm
         onView(withContentDescription(formattedDate))
                 .inRoot(RootMatchers.isDialog())
                 .perform(click());
         onView(withId(com.google.android.material.R.id.confirm_button)).perform(click());
+        // Return HomePage's formatted date
+        return currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 
     @Test
     public void testAddItemWithValidData() {
-        String itemDescription = "Test Item";
-        // Add brief description
-        onView(withId(R.id.add_item_description)).perform(replaceText(itemDescription), closeSoftKeyboard());
         // Add acquisition date
-        selectFirstDayOfMonth();
-        // Add an estimated cost
-        onView(withId(R.id.add_item_cost)).perform(replaceText("100"), closeSoftKeyboard());
-        // TODO: Add other relevant fields
+        String acquisitionDate = selectFirstDayOfMonth();
+        // Add required description and estimated cost
+        String itemDescription = "Test Item";
+        String estimatedCost = "99.99";
+        onView(withId(R.id.add_item_description)).perform(replaceText(itemDescription), closeSoftKeyboard());
+        onView(withId(R.id.add_item_cost)).perform(replaceText(estimatedCost), closeSoftKeyboard());
+        // Add values to other non-required fields
+        onView(withId(R.id.add_item_make)).perform(replaceText("MyMake"), closeSoftKeyboard());
+        onView(withId(R.id.add_item_model)).perform(replaceText("MyModel"), closeSoftKeyboard());
+        onView(withId(R.id.add_item_serial_number)).perform(replaceText("1234567890"), closeSoftKeyboard());
+        onView(withId(R.id.add_item_comment)).perform(replaceText("this is a comment"), closeSoftKeyboard());
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());
         // Check that we switch back to home page
         waitForView(withId(R.id.item_list));
-        // Check that the item is present in the list
+        // Check that the item in list matches description, date, and cost
         onData(anything())
                 .inAdapterView(withId(R.id.item_list))
                 .atPosition(0)
                 .onChildView(withId(R.id.item_description_text))
                 .check(matches(withText(itemDescription)));
+        onData(anything())
+                .inAdapterView(withId(R.id.item_list))
+                .atPosition(0)
+                .onChildView(withId(R.id.item_text))
+                .check(matches(withText(acquisitionDate + " | $" + estimatedCost)));
     }
 }

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -58,9 +58,9 @@ public class AddItemFragmentTest extends TestSetup {
         enterText(R.id.add_item_make, "MyMake");
         enterText(R.id.add_item_model, "MyModel");
         enterText(R.id.add_item_serial_number, "1234567890");
-        onView(withId(R.id.add_item_comment)).perform(scrollTo());
-        waitForView(withId(R.id.add_item_comment));
-        enterText(R.id.add_item_comment, "this is a comment");
+//        onView(withId(R.id.add_item_comment)).perform(scrollTo());
+//        waitForView(withId(R.id.add_item_comment));
+//        enterText(R.id.add_item_comment, "this is a comment");
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());
         // Check that we switch back to home page

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -3,6 +3,7 @@ package com.example.househomey;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
@@ -57,6 +58,7 @@ public class AddItemFragmentTest extends TestSetup {
         enterText(R.id.add_item_make, "MyMake");
         enterText(R.id.add_item_model, "MyModel");
         enterText(R.id.add_item_serial_number, "1234567890");
+        onView(withId(R.id.add_item_comment)).perform(scrollTo());
         enterText(R.id.add_item_comment, "this is a comment");
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -58,9 +58,9 @@ public class AddItemFragmentTest extends TestSetup {
         enterText(R.id.add_item_make, "MyMake");
         enterText(R.id.add_item_model, "MyModel");
         enterText(R.id.add_item_serial_number, "1234567890");
-//        onView(withId(R.id.add_item_comment)).perform(scrollTo());
-//        waitForView(withId(R.id.add_item_comment));
-//        enterText(R.id.add_item_comment, "this is a comment");
+        onView(withId(R.id.add_item_comment)).perform(scrollTo());
+        waitForView(withId(R.id.add_item_comment));
+        enterText(R.id.add_item_comment, "this is a comment");
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());
         // Check that we switch back to home page

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -3,13 +3,14 @@ package com.example.househomey;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static com.example.househomey.testUtils.EspressoWait.waitForView;
+import static com.example.househomey.testUtils.TestHelpers.enterText;
+import static com.example.househomey.testUtils.TestHelpers.hasListLength;
+import static com.example.househomey.testUtils.TestHelpers.waitForView;
 import static org.hamcrest.CoreMatchers.anything;
 
 import androidx.test.espresso.matcher.RootMatchers;
@@ -50,17 +51,18 @@ public class AddItemFragmentTest extends TestSetup {
         // Add required description and estimated cost
         String itemDescription = "Test Item";
         String estimatedCost = "99.99";
-        onView(withId(R.id.add_item_description)).perform(replaceText(itemDescription), closeSoftKeyboard());
-        onView(withId(R.id.add_item_cost)).perform(replaceText(estimatedCost), closeSoftKeyboard());
+        enterText(R.id.add_item_description, itemDescription);
+        enterText(R.id.add_item_cost, estimatedCost);
         // Add values to other non-required fields
-        onView(withId(R.id.add_item_make)).perform(replaceText("MyMake"), closeSoftKeyboard());
-        onView(withId(R.id.add_item_model)).perform(replaceText("MyModel"), closeSoftKeyboard());
-        onView(withId(R.id.add_item_serial_number)).perform(replaceText("1234567890"), closeSoftKeyboard());
-        onView(withId(R.id.add_item_comment)).perform(replaceText("this is a comment"), closeSoftKeyboard());
+        enterText(R.id.add_item_make, "MyMake");
+        enterText(R.id.add_item_model, "MyModel");
+        enterText(R.id.add_item_serial_number, "1234567890");
+        enterText(R.id.add_item_comment, "this is a comment");
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());
         // Check that we switch back to home page
         waitForView(withId(R.id.item_list));
+        hasListLength(1);
         // Check that the item in list matches description, date, and cost
         onData(anything())
                 .inAdapterView(withId(R.id.item_list))
@@ -72,5 +74,30 @@ public class AddItemFragmentTest extends TestSetup {
                 .atPosition(0)
                 .onChildView(withId(R.id.item_text))
                 .check(matches(withText(acquisitionDate + " | $" + estimatedCost)));
+    }
+
+    @Test
+    public void testSubmitWithRequiredEmpty() {
+        String defaultErrorMsg = "This field is required";
+        // Click the add button with empty form
+        onView(withId(R.id.add_item_confirm_button)).perform(click());
+        // Check that error messages are displayed in TextInputLayouts for required fields
+        onView(withId(R.id.add_item_description_layout)).check(matches(hasDescendant(withText(defaultErrorMsg))));
+        onView(withId(R.id.add_item_cost_layout)).check(matches(hasDescendant(withText(defaultErrorMsg))));
+        onView(withId(R.id.add_item_date_layout)).check(matches(hasDescendant(withText(defaultErrorMsg))));
+    }
+
+    @Test
+    public void testBackButtonGoesToHomePage() {
+        onView(withId(R.id.add_item_back_button)).perform(click());
+        // Check that we switch back to home page with empty list
+        waitForView(withId(R.id.item_list));
+        hasListLength(0);
+    }
+
+    @Test
+    public void testRoundCostTo2Decimals() {
+        enterText(R.id.add_item_cost, "99.9852323324");
+        onView(withId(R.id.add_item_cost)).check(matches(withText("99.99")));
     }
 }

--- a/app/src/androidTest/java/com/example/househomey/testUtils/DatabaseSetupRule.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/DatabaseSetupRule.java
@@ -1,0 +1,130 @@
+package com.example.househomey.testUtils;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ActivityScenario;
+
+import com.example.househomey.MainActivity;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A JUnit TestRule that provides the ability to create and delete a unique test user document for each test.
+ * NOTE: this Rule will only create a unique user for the test IF
+ *      the test method contains the `methodMatcher` as part of its name.
+ *
+ * @author Owen Cooke
+ */
+public class DatabaseSetupRule<T extends Activity> implements TestRule {
+    private final String methodMatcher = "WithNewUser";
+    private final Class<T> activityClass;
+    private DocumentReference userDoc;
+    private boolean isDatabaseTest;
+
+    public DatabaseSetupRule(Class<T> activityClass) {
+        this.activityClass = activityClass;
+    }
+
+    /**
+     * Sets up the activity by launching it, providing user data via an intent.
+     * The user data includes the user document's ID, or null if the test does not require a unique user.
+     * TODO: we can replace the "null" test user with an actual username, and prepopulate that user
+     *      in Firebase for testing non-DB updates (such as list formatting, item filtering, sorting, etc.)
+     */
+    public void setupActivity() {
+        Bundle userData = new Bundle();
+        userData.putString("username", isDatabaseTest ? userDoc.getId() : "null");
+        ActivityScenario.launch(activityClass).onActivity(activity -> {
+            Intent intent = new Intent(activity, MainActivity.class);
+            intent.putExtra("userData", userData);
+            activity.startActivity(intent);
+        });
+    }
+
+    @Override
+    public Statement apply(@NonNull Statement base, @NonNull Description description) {
+        // Check if the test method name indicates that new user Firestore setup is needed
+        String methodName = description.getMethodName();
+        isDatabaseTest = methodName.contains(methodMatcher);
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                if (isDatabaseTest) {
+                    createTestUser();
+                }
+                try {
+                    // Run the actual @Test method body
+                    base.evaluate();
+                } finally {
+                    if (isDatabaseTest) {
+                        deleteTestUser();
+                    }
+                }
+            }
+        };
+    }
+
+    private void createTestUser() throws Exception {
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        CountDownLatch latch = new CountDownLatch(1);
+        db.collection("user").add(new HashMap<String, Object>()).addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                userDoc = task.getResult();
+                latch.countDown();
+            } else {
+                throw new RuntimeException("Could not generate a unique test user.");
+            }
+        });
+        // Wait for user creation to finish
+        if (!latch.await(10, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timeout waiting for test user creation.");
+        }
+    }
+
+    public void deleteTestUser() throws Exception {
+        if (userDoc != null) {
+            CountDownLatch latch = new CountDownLatch(1);
+            // Need to delete all nested collections before user doc can be deleted
+            deleteNestedDocuments(userDoc.collection("item"));
+            userDoc.delete()
+                    .addOnSuccessListener(aVoid -> {
+                        Log.d("ESP-TEST", "Unique test user document deleted successfully");
+                        latch.countDown();
+                    })
+                    .addOnFailureListener(e -> {
+                        Log.e("ESP-TEST", "Could not delete the unique test user: " + e.getMessage());
+                        latch.countDown();
+                    });
+            // Wait for all deletions to finish
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Timeout waiting for test user deletion.");
+            }
+        }
+    }
+
+    private void deleteNestedDocuments(CollectionReference collection) {
+        collection.get().addOnSuccessListener(queryDocumentSnapshots -> {
+            for (QueryDocumentSnapshot document : queryDocumentSnapshots) {
+                DocumentReference docRef = document.getReference();
+                docRef.delete()
+                        .addOnSuccessListener(aVoid -> Log.d("ESP-TEST", "Nested document deleted successfully"))
+                        .addOnFailureListener(e -> Log.e("ESP-TEST", "Could not delete nested document: " + e.getMessage()));
+            }
+        }).addOnFailureListener(e -> Log.e("ESP-TEST", "Could not retrieve nested documents: " + e.getMessage()));
+    }
+}
+

--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
@@ -3,6 +3,7 @@ package com.example.househomey.testUtils;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.matcher.ViewMatchers.hasChildCount;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -74,6 +75,6 @@ public class TestHelpers {
      * @param text   The text to be entered into the view.
      */
     public static void enterText(@IdRes int viewId, String text) {
-        onView(withId(viewId)).perform(typeText(text), pressImeActionButton(), closeSoftKeyboard());
+        onView(withId(viewId)).perform(scrollTo(), typeText(text), pressImeActionButton(), closeSoftKeyboard());
     }
 }

--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
@@ -1,15 +1,24 @@
 package com.example.househomey.testUtils;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.matcher.ViewMatchers.hasChildCount;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 import android.view.View;
 
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.annotation.IdRes;
+
+import com.example.househomey.R;
 
 import org.hamcrest.Matcher;
 
-public class EspressoWait {
+public class TestHelpers {
     private static final long TIMEOUT = 5000; // Timeout in milliseconds
     private static final long POLLING_INTERVAL = 500; // Polling interval in milliseconds
 
@@ -37,5 +46,12 @@ public class EspressoWait {
             throw new AssertionError("View matching the given Matcher was not displayed within the timeout. " + e);
         }
     }
-}
 
+    public static void hasListLength(int expectedCount) {
+        onView(withId(R.id.item_list)).check(matches(hasChildCount(expectedCount)));
+    }
+
+    public static void enterText(@IdRes int viewId, String text) {
+        onView(withId(viewId)).perform(typeText(text), pressImeActionButton(), closeSoftKeyboard());
+    }
+}

--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
@@ -18,10 +18,19 @@ import com.example.househomey.R;
 
 import org.hamcrest.Matcher;
 
+/**
+ * Helper methods for Espresso testing in Android applications.
+ * @author Owen Cooke
+ */
 public class TestHelpers {
     private static final long TIMEOUT = 5000; // Timeout in milliseconds
     private static final long POLLING_INTERVAL = 500; // Polling interval in milliseconds
 
+    /**
+     * Wait for a view to be displayed within a specified timeout (5s).
+     *
+     * @param viewMatcher The Matcher for the view to wait for.
+     */
     public static void waitForView(Matcher<View> viewMatcher) {
         long startTime = System.currentTimeMillis();
         long elapsedTime = 0;
@@ -47,10 +56,23 @@ public class TestHelpers {
         }
     }
 
+    /**
+     * Check if the list of Items has the expected number of Items.
+     *
+     * @param expectedCount The expected number of child elements in the list view.
+     */
     public static void hasListLength(int expectedCount) {
         onView(withId(R.id.item_list)).check(matches(hasChildCount(expectedCount)));
     }
 
+    /**
+     * Types text into an EditText field.
+     * Presses the IME action button, for actions like "Done," "Search," or "Next"
+     * that follow entering text. Also ensures the keyboard is closed.
+     *
+     * @param viewId The resource ID of the EditText view.
+     * @param text   The text to be entered into the view.
+     */
     public static void enterText(@IdRes int viewId, String text) {
         onView(withId(viewId)).perform(typeText(text), pressImeActionButton(), closeSoftKeyboard());
     }

--- a/app/src/main/java/com/example/househomey/ItemAdapter.java
+++ b/app/src/main/java/com/example/househomey/ItemAdapter.java
@@ -15,6 +15,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.ArrayList;
 
 /**
@@ -25,6 +27,7 @@ import java.util.ArrayList;
 public class ItemAdapter extends ArrayAdapter<Item> {
     private ArrayList<Item> items;
     private Context context;
+    private SimpleDateFormat dateFormat;
 
     /**
      * Constructs a new ItemAdapter with an ArrayList of items
@@ -35,6 +38,8 @@ public class ItemAdapter extends ArrayAdapter<Item> {
         super(context, 0, items);
         this.items = items;
         this.context = context;
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.CANADA);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
 
@@ -66,8 +71,7 @@ public class ItemAdapter extends ArrayAdapter<Item> {
 
         // Set all the text views to their appropriate values
         ((TextView) view.findViewById(R.id.item_description_text)).setText(item.getDescription());
-
-        String dateCost = new SimpleDateFormat("yyyy-MM-dd").format(item.getAcquisitionDate()) + " | $" + item.getCost();
+        String dateCost = dateFormat.format(item.getAcquisitionDate()) + " | $" + item.getCost();
         ((TextView) view.findViewById(R.id.item_text)).setText(dateCost);
 
         // Initialize button for viewing details of the item

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,15 +10,17 @@
     <FrameLayout
         android:id="@+id/fragmentContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_above="@id/bottom_navigation"
+        android:layout_alignParentTop="true" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
-        app:itemActiveIndicatorStyle="@style/App.Custom.Indicator"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/brown"
+        app:itemActiveIndicatorStyle="@style/App.Custom.Indicator"
         app:itemIconTint="@color/white"
         app:menu="@menu/navbar" />
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -53,7 +53,7 @@
             app:iconTint="@color/white" />
     </LinearLayout>
 
-    <androidx.core.widget.NestedScrollView
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -230,6 +230,6 @@
 
         </LinearLayout>
 
-    </androidx.core.widget.NestedScrollView>
+    </ScrollView>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -55,7 +55,9 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginBottom="16dp"
+        >
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -223,10 +225,6 @@
                     android:layout_height="wrap_content"
                     android:maxLength="280" />
             </com.google.android.material.textfield.TextInputLayout>
-
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="48dp" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_view_item.xml
+++ b/app/src/main/res/layout/fragment_view_item.xml
@@ -172,14 +172,21 @@
         android:orientation="horizontal"
         android:layout_marginTop="16dp">
 
+        <Space
+            android:layout_width="32dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"/>
+
         <Button
             android:id="@+id/edit_button"
             android:layout_width="160dp"
             android:layout_height="match_parent"
             android:layout_gravity="center"
             android:text="Edit Item"
-            android:layout_marginStart="64dp"
-            android:layout_marginEnd="32dp"
+            android:layout_weight="1"/>
+        <Space
+            android:layout_width="32dp"
+            android:layout_height="match_parent"
             android:layout_weight="1"/>
 
         <Button
@@ -188,13 +195,16 @@
             android:layout_height="match_parent"
             android:layout_alignParentEnd="true"
             android:layout_gravity="center"
-            android:layout_marginStart="32dp"
-            android:layout_marginEnd="64dp"
+
             android:text="Delete"
             android:backgroundTint="@color/red"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/edit_button"
+            android:layout_weight="1"/>
+        <Space
+            android:layout_width="32dp"
+            android:layout_height="match_parent"
             android:layout_weight="1"/>
     </LinearLayout>
 


### PR DESCRIPTION
### Describe your changes
This PR accomplishes the following:
- finished Espresso tests for the Add Item fragment
- adds helper functions for testing item list length and entering text into EditText fields
- modifies the TestSetup class to use a new custom Espresso Rule that allow us to create unique Firebase users for tests that modify/edit data. 
    - this should allow more accurate CI, since tests won't be interfering
    - the unique user creation is only done when you explicitly specify it (via naming your test method anything that contains `WithNewUser` like the format below:
    

```java
@Test
public void testAddItemWithNewUser() 
// creates a new unique FB user

@Test 
public void testFormFields() 
// does not create a unique user
```

We can then define a default test user with pre-made data in FB to use for tests that don't modify data (like checking list formatting, values on view item page, filtering, sorting, etc.)

### Issue ticket number and link
This PR addresses: https://github.com/CMPUT301F23T08/HouseHomey/issues/6

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Necessary java docs are present
- [ ] Necessary UML diagrams are created
- [x] Necessary tests are written

NOTE: we found an error in our fragment container; it was not properly constrained to our bottom navigation bar, which led to improper scrolling/clicking on the Add Item page.

So note that `scrollTo` is a useful method to assure that elements in a scrollable container are actually showing