### PR TITLE
Edit Item Espresso tests and Add method to mock Items for Firestore test users

### DIFF
--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -3,15 +3,15 @@ package com.example.househomey;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.example.househomey.testUtils.TestHelpers.enterText;
 import static com.example.househomey.testUtils.TestHelpers.hasListLength;
-import static com.example.househomey.testUtils.TestHelpers.waitForView;
+import static com.example.househomey.testUtils.TestHelpers.waitFor;
 import static org.hamcrest.CoreMatchers.anything;
 
 import androidx.test.espresso.matcher.RootMatchers;
@@ -58,14 +58,11 @@ public class AddItemFragmentTest extends TestSetup {
         enterText(R.id.add_item_make, "MyMake");
         enterText(R.id.add_item_model, "MyModel");
         enterText(R.id.add_item_serial_number, "1234567890");
-        onView(withId(R.id.add_item_comment)).perform(scrollTo());
-        waitForView(withId(R.id.add_item_comment));
         enterText(R.id.add_item_comment, "this is a comment");
         // Click the confirm button to add the item
         onView(withId(R.id.add_item_confirm_button)).perform(click());
-        // Check that we switch back to home page
-        waitForView(withId(R.id.item_list));
-        hasListLength(1);
+        // Wait for Firebase to update list on home page
+        waitFor(() ->  hasListLength(1));
         // Check that the item in list matches description, date, and cost
         onData(anything())
                 .inAdapterView(withId(R.id.item_list))
@@ -93,7 +90,7 @@ public class AddItemFragmentTest extends TestSetup {
     @Test
     public void testBackButtonGoesToHomePage() {
         onView(withId(R.id.add_item_back_button)).perform(click());
-        waitForView(withId(R.id.item_list));
+        onView(withId(R.id.item_list)).check(matches(isDisplayed()));
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/AddItemFragmentTest.java
@@ -93,9 +93,7 @@ public class AddItemFragmentTest extends TestSetup {
     @Test
     public void testBackButtonGoesToHomePage() {
         onView(withId(R.id.add_item_back_button)).perform(click());
-        // Check that we switch back to home page with empty list
         waitForView(withId(R.id.item_list));
-        hasListLength(0);
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
@@ -34,7 +34,7 @@ public class EditItemFragmentTest extends TestSetup {
     @Before
     public void navigateToEditItemFragment() throws Exception {
         // Create mock initial item in DB
-        super.databaseRule.addMockItem(mockData);
+        database.addMockItem(mockData);
         // Click to view the item page
         onData(anything())
                 .inAdapterView(withId(R.id.item_list))
@@ -64,5 +64,11 @@ public class EditItemFragmentTest extends TestSetup {
         // Check that the unedited fields remain the same
         onView(withId(R.id.view_item_serial_number)).check(matches(withText(mockData.get("serialNumber").toString())));
         onView(withId(R.id.view_item_model)).check(matches(withText(mockData.get("model").toString())));
+    }
+
+    @Test
+    public void testBackButtonGoesToViewItemPage() {
+        onView(withId(R.id.add_item_back_button)).perform(click());
+        waitForView(withId(R.id.view_item_make));
     }
 }

--- a/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
@@ -6,10 +6,11 @@ import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.example.househomey.testUtils.TestHelpers.enterText;
-import static com.example.househomey.testUtils.TestHelpers.waitForView;
+import static com.example.househomey.testUtils.TestHelpers.waitFor;
 import static org.hamcrest.CoreMatchers.anything;
 
 import com.example.househomey.testUtils.TestSetup;
@@ -36,9 +37,8 @@ public class EditItemFragmentTest extends TestSetup {
     @Before
     public void navigateToEditItemFragment() throws Exception {
         // Create mock initial item in DB
-        database.addMockItem(mockData);
+        database.addTestItem(mockData);
         // Click to view the item page
-        waitForView(withId(R.id.item_list));
         onData(anything())
                 .inAdapterView(withId(R.id.item_list))
                 .atPosition(0)
@@ -60,19 +60,20 @@ public class EditItemFragmentTest extends TestSetup {
         // Click the confirm button to make edits
         onView(withId(R.id.add_item_confirm_button)).perform(click());
         // Check that edits appear on view item page
-        waitForView(withId(R.id.view_item_make));
-        onView(withId(R.id.view_item_cost)).check(matches(withText(cost)));
-        onView(withId(R.id.view_item_comment)).check(matches(withText(comment)));
-        onView(withId(R.id.view_item_make)).check(matches(withText(make)));
-        // Check that the unedited fields remain the same
-        onView(withId(R.id.view_item_serial_number)).check(matches(withText(mockData.get("serialNumber").toString())));
-        onView(withId(R.id.view_item_model)).check(matches(withText(mockData.get("model").toString())));
+        waitFor(() -> {
+            onView(withId(R.id.view_item_cost)).check(matches(withText(cost)));
+            onView(withId(R.id.view_item_comment)).check(matches(withText(comment)));
+            onView(withId(R.id.view_item_make)).check(matches(withText(make)));
+            // Check that the unedited fields remain the same
+            onView(withId(R.id.view_item_serial_number)).check(matches(withText(mockData.get("serialNumber").toString())));
+            onView(withId(R.id.view_item_model)).check(matches(withText(mockData.get("model").toString())));
+        });
     }
 
     @Test
     public void testBackButtonGoesToViewItemPage() {
         onView(withId(R.id.add_item_back_button)).perform(click());
-        waitForView(withId(R.id.view_item_make));
+        onView(withId(R.id.view_item_make)).check(matches(isDisplayed()));
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
@@ -2,8 +2,10 @@ package com.example.househomey;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.example.househomey.testUtils.TestHelpers.enterText;
@@ -36,6 +38,7 @@ public class EditItemFragmentTest extends TestSetup {
         // Create mock initial item in DB
         database.addMockItem(mockData);
         // Click to view the item page
+        waitForView(withId(R.id.item_list));
         onData(anything())
                 .inAdapterView(withId(R.id.item_list))
                 .atPosition(0)
@@ -70,5 +73,19 @@ public class EditItemFragmentTest extends TestSetup {
     public void testBackButtonGoesToViewItemPage() {
         onView(withId(R.id.add_item_back_button)).perform(click());
         waitForView(withId(R.id.view_item_make));
+    }
+
+    @Test
+    public void testRemovingRequiredFieldWontSubmit() {
+        String defaultErrorMsg = "This field is required";
+        // Clear required fields
+        onView(withId(R.id.add_item_description)).perform(clearText());
+        onView(withId(R.id.add_item_date)).perform(clearText());
+        onView(withId(R.id.add_item_cost)).perform(clearText());
+        // Try submitting and check that error fields are shown
+        onView(withId(R.id.add_item_confirm_button)).perform(click());
+        onView(withId(R.id.add_item_description_layout)).check(matches(hasDescendant(withText(defaultErrorMsg))));
+        onView(withId(R.id.add_item_cost_layout)).check(matches(hasDescendant(withText(defaultErrorMsg))));
+        onView(withId(R.id.add_item_date_layout)).check(matches(hasDescendant(withText(defaultErrorMsg))));
     }
 }

--- a/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
+++ b/app/src/androidTest/java/com/example/househomey/EditItemFragmentTest.java
@@ -1,0 +1,68 @@
+package com.example.househomey;
+
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.example.househomey.testUtils.TestHelpers.enterText;
+import static com.example.househomey.testUtils.TestHelpers.waitForView;
+import static org.hamcrest.CoreMatchers.anything;
+
+import com.example.househomey.testUtils.TestSetup;
+import com.google.common.collect.ImmutableMap;
+import com.google.firebase.Timestamp;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.Map;
+
+public class EditItemFragmentTest extends TestSetup {
+    private final Map<String, Object> mockData = ImmutableMap.of(
+            "description", "Test Item",
+            "acquisitionDate", new Timestamp(new Date()),
+            "cost", "99.99",
+            "make", "oldMake",
+            "model", "oldModel",
+            "serialNumber", "020202020",
+            "comment", "original comment"
+    );
+
+    @Before
+    public void navigateToEditItemFragment() throws Exception {
+        // Create mock initial item in DB
+        super.databaseRule.addMockItem(mockData);
+        // Click to view the item page
+        onData(anything())
+                .inAdapterView(withId(R.id.item_list))
+                .atPosition(0)
+                .onChildView(withId(R.id.action_view))
+                .perform(click());
+        // Click on edit button
+        onView(withId(R.id.edit_button)).perform(click());
+    }
+
+    @Test
+    public void testEditItemWithNewUser() {
+        String cost = "222.22";
+        String make = "NewMake";
+        String comment = "this is an edited comment";
+        // Edit the cost/comment/make
+        enterText(R.id.add_item_cost, cost);
+        enterText(R.id.add_item_make, make);
+        enterText(R.id.add_item_comment, comment);
+        // Click the confirm button to make edits
+        onView(withId(R.id.add_item_confirm_button)).perform(click());
+        // Check that edits appear on view item page
+        waitForView(withId(R.id.view_item_make));
+        onView(withId(R.id.view_item_cost)).check(matches(withText(cost)));
+        onView(withId(R.id.view_item_comment)).check(matches(withText(comment)));
+        onView(withId(R.id.view_item_make)).check(matches(withText(make)));
+        // Check that the unedited fields remain the same
+        onView(withId(R.id.view_item_serial_number)).check(matches(withText(mockData.get("serialNumber").toString())));
+        onView(withId(R.id.view_item_model)).check(matches(withText(mockData.get("model").toString())));
+    }
+}

--- a/app/src/androidTest/java/com/example/househomey/testUtils/DatabaseSetupRule.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/DatabaseSetupRule.java
@@ -36,6 +36,7 @@ public class DatabaseSetupRule<T extends Activity> implements TestRule {
     private final Class<T> activityClass;
     private DocumentReference userDoc;
     private boolean isDatabaseTest;
+    private final int dbTimeoutInSeconds = 30;
 
     public DatabaseSetupRule(Class<T> activityClass) {
         this.activityClass = activityClass;
@@ -81,7 +82,7 @@ public class DatabaseSetupRule<T extends Activity> implements TestRule {
                 throw new RuntimeException("Adding mock item to Firestore failed with: " + e.getMessage());
             });
             // Wait for item creation to finish
-            if (!latch.await(10, TimeUnit.SECONDS)) {
+            if (!latch.await(dbTimeoutInSeconds, TimeUnit.SECONDS)) {
                 throw new RuntimeException("Timeout waiting for test user creation.");
             }
         }
@@ -122,7 +123,7 @@ public class DatabaseSetupRule<T extends Activity> implements TestRule {
             }
         });
         // Wait for user creation to finish
-        if (!latch.await(10, TimeUnit.SECONDS)) {
+        if (!latch.await(dbTimeoutInSeconds, TimeUnit.SECONDS)) {
             throw new RuntimeException("Timeout waiting for test user creation.");
         }
     }
@@ -142,7 +143,7 @@ public class DatabaseSetupRule<T extends Activity> implements TestRule {
                         latch.countDown();
                     });
             // Wait for all deletions to finish
-            if (!latch.await(10, TimeUnit.SECONDS)) {
+            if (!latch.await(dbTimeoutInSeconds, TimeUnit.SECONDS)) {
                 throw new RuntimeException("Timeout waiting for test user deletion.");
             }
         }

--- a/app/src/androidTest/java/com/example/househomey/testUtils/DatabaseSetupRule.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/DatabaseSetupRule.java
@@ -66,7 +66,7 @@ public class DatabaseSetupRule<T extends Activity> implements TestRule {
      * @throws RuntimeException if the mock data cannot create a valid Item, if adding the mock item to Firestore
      * fails, or if there is a timeout waiting for the operation to complete.
      */
-    public void addMockItem(Map<String, Object> itemDetails) throws Exception {
+    public void addTestItem(Map<String, Object> itemDetails) throws Exception {
         if (userDoc != null) {
             // Ensure that mock data can be used to create a valid Item
             Item item;

--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
@@ -6,42 +6,37 @@ import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.action.ViewActions.typeText;
-import static androidx.test.espresso.matcher.ViewMatchers.hasChildCount;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-
-import android.view.View;
-
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasChildCount;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 import androidx.annotation.IdRes;
 
 import com.example.househomey.R;
 
-import org.hamcrest.Matcher;
-
 /**
  * Helper methods for Espresso testing in Android applications.
+ *
  * @author Owen Cooke
  */
 public class TestHelpers {
-    private static final long TIMEOUT = 5000; // Timeout in milliseconds
+    private static final long TIMEOUT = 10000; // Timeout in milliseconds
     private static final long POLLING_INTERVAL = 500; // Polling interval in milliseconds
 
     /**
-     * Wait for a view to be displayed within a specified timeout (5s).
+     * Wait for a lambda function to execute without error within a specified timeout.
+     * Intended use is for wrapping Espresso statements that rely on Firebase changes,
+     * which potentially take additional time to update.
      *
-     * @param viewMatcher The Matcher for the view to wait for.
+     * @param lambda The Espresso statement to execute.
      */
-    public static void waitForView(Matcher<View> viewMatcher) {
+    public static void waitFor(Runnable lambda) {
         long startTime = System.currentTimeMillis();
         long elapsedTime = 0;
-
-        // Try to match multiple times during timeout
         while (elapsedTime < TIMEOUT) {
             try {
-                onView(viewMatcher).check(matches(isDisplayed()));
-                return; // View is displayed, exit
+                lambda.run();
+                return; // Statement executed successfully, exit
             } catch (Exception ignore) {
             }
             try {
@@ -50,11 +45,11 @@ public class TestHelpers {
             }
             elapsedTime = System.currentTimeMillis() - startTime;
         }
-        // Try one last time, otherwise error out with added description
+        // Retry one last time, otherwise error out with added description
         try {
-            onView(viewMatcher).check(matches(isDisplayed()));
+            lambda.run();
         } catch (Exception e) {
-            throw new AssertionError("View matching the given Matcher was not displayed within the timeout. " + e);
+            throw new AssertionError("Espresso statement did not succeed within the timeout. " + e.getMessage());
         }
     }
 

--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestHelpers.java
@@ -1,6 +1,7 @@
 package com.example.househomey.testUtils;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
@@ -75,6 +76,6 @@ public class TestHelpers {
      * @param text   The text to be entered into the view.
      */
     public static void enterText(@IdRes int viewId, String text) {
-        onView(withId(viewId)).perform(scrollTo(), typeText(text), pressImeActionButton(), closeSoftKeyboard());
+        onView(withId(viewId)).perform(scrollTo(), clearText(), typeText(text), pressImeActionButton(), closeSoftKeyboard());
     }
 }

--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestSetup.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestSetup.java
@@ -19,14 +19,13 @@ import java.io.IOException;
 /**
  * An abstract class for setting up Espresso test functionality required for both
  * Firebase and our Github Actions CI pipeline. Simply extend your test class with this class.
- *
  * For methods that require a unique Firebase user, ensure the method name includes "WithNewUser"
  *
  * @author Owen Cooke
  */
 public abstract class TestSetup {
     @Rule
-    public DatabaseSetupRule<MainActivity> databaseRule = new DatabaseSetupRule<>(MainActivity.class);
+    public DatabaseSetupRule<MainActivity> database = new DatabaseSetupRule<>(MainActivity.class);
 
     @BeforeClass
     public static void dismissANRSystemDialog() throws UiObjectNotFoundException {
@@ -50,6 +49,6 @@ public abstract class TestSetup {
 
     @Before
     public void setup() {
-        databaseRule.setupActivity();
+        database.setupActivity();
     }
 }


### PR DESCRIPTION
### Describe your changes

This PR accomplishes the following:

- adds Espresso tests for the Edit Item page
- adds a method for creating a test item in the auto-generated Firebase test user's items
- replaces `waitForView` with a more general `waitFor` method, to prevent tests failing due to slow Firebase updates

### Issue ticket number and link

This PR addresses: https://github.com/CMPUT301F23T08/HouseHomey/issues/14

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Necessary java docs are present
- [ ] Necessary UML diagrams are created
- [x] Necessary tests are written
