### PR TITLE
[BUG] small fix to prevent Android system dialogs from ruining Espresso Tests

### DIFF
--- a/app/src/androidTest/java/com/example/househomey/testUtils/TestSetup.java
+++ b/app/src/androidTest/java/com/example/househomey/testUtils/TestSetup.java
@@ -11,7 +11,6 @@ import androidx.test.uiautomator.UiSelector;
 import com.example.househomey.MainActivity;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 
 import java.io.IOException;
@@ -27,8 +26,8 @@ public abstract class TestSetup {
     @Rule
     public DatabaseSetupRule<MainActivity> database = new DatabaseSetupRule<>(MainActivity.class);
 
-    @BeforeClass
-    public static void dismissANRSystemDialog() throws UiObjectNotFoundException {
+    @Before
+    public void dismissANRSystemDialog() throws UiObjectNotFoundException {
         UiDevice device = UiDevice.getInstance(getInstrumentation());
         // If the device is running in English Locale
         UiObject waitButton = device.findObject(new UiSelector().textContains("wait"));
@@ -37,8 +36,8 @@ public abstract class TestSetup {
         }
     }
 
-    @BeforeClass
-    public static void dismissAppCrashSystemDialogIfShown() {
+    @Before
+    public void dismissAppCrashSystemDialogIfShown() {
         try {
             UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
                     .executeShellCommand("am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS");


### PR DESCRIPTION
### Describe your changes

This PR accomplishes the following:

- changes the System Dialog removers to run `@Before` instead of `@BeforeClass`.
 
Now that we have long Firebase setup calls, we want to make sure these System Dialog removers are called after the Firebase setup and before our Espresso test. I believe right now they are being run before both, which is causing the CI to crash with the dialog errors b/c Firebase can take a long time.
