### PR TITLE
[US 04.01.01 and US 04.02.01] Implement Photo Adding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,10 @@ android {
 dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.4.0"))
     implementation("com.google.firebase:firebase-firestore")
+    implementation("com.google.firebase:firebase-storage")
+    implementation("com.firebaseui:firebase-ui-storage:7.2.0")
+    implementation("com.github.bumptech.glide:glide:4.12.0")
+    annotationProcessor("com.github.bumptech.glide:compiler:4.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")

--- a/app/src/main/java/com/example/househomey/Item.java
+++ b/app/src/main/java/com/example/househomey/Item.java
@@ -171,10 +171,20 @@ public class Item implements Serializable, Parcelable {
         return comment;
     }
 
+    /**
+     * Getter for photoIds
+     *
+     * @return List of Cloud Storage photo IDs associated with this Item
+     */
     public List<String> getPhotoIds() {
         return photoIds;
     }
 
+    /**
+     * Setter for photoIds
+     *
+     * @param photoIds List of Cloud Storage photo IDs to set for this Item
+     */
     public void setPhotoIds(List<String> photoIds) {
         this.photoIds = photoIds;
     }
@@ -206,6 +216,7 @@ public class Item implements Serializable, Parcelable {
         out.writeString(serialNumber);
         out.writeString(comment);
         out.writeSerializable(cost.toString());
+        out.writeSerializable(photoIds.toArray());
     }
 
     /**
@@ -221,6 +232,7 @@ public class Item implements Serializable, Parcelable {
         this.serialNumber = in.readString();
         this.comment = in.readString();
         this.cost = new BigDecimal(in.readString()).setScale(2, RoundingMode.HALF_UP);
+        this.photoIds = in.createStringArrayList();
     }
 
     /**

--- a/app/src/main/java/com/example/househomey/Item.java
+++ b/app/src/main/java/com/example/househomey/Item.java
@@ -10,8 +10,10 @@ import com.google.firebase.Timestamp;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -29,6 +31,7 @@ public class Item implements Serializable, Parcelable {
     private String serialNumber = "";
     private String comment = "";
     private BigDecimal cost;
+    private List<String> photoIds = new ArrayList<>();
 
     /**
      * This constructs a new item from a Map of data with a reference to its Firestore document
@@ -57,6 +60,9 @@ public class Item implements Serializable, Parcelable {
         if (data.containsKey("comment")) {
             this.comment = (String) data.get("comment");
         }
+        if (data.containsKey("photoIds")) {
+            this.photoIds = new ArrayList<>((List<String>) data.get("photoIds"));
+        }
     }
 
     /**
@@ -84,6 +90,9 @@ public class Item implements Serializable, Parcelable {
         }
         if (!comment.isEmpty()) {
             itemData.put("comment", comment);
+        }
+        if (!photoIds.isEmpty()) {
+            itemData.put("photoIds", photoIds);
         }
         return itemData;
     }
@@ -162,6 +171,13 @@ public class Item implements Serializable, Parcelable {
         return comment;
     }
 
+    public List<String> getPhotoIds() {
+        return photoIds;
+    }
+
+    public void setPhotoIds(List<String> photoIds) {
+        this.photoIds = photoIds;
+    }
 
     //Creating the Parcelable CREATOR and
     //Implementing the Parcelable Interface below

--- a/app/src/main/java/com/example/househomey/MainActivity.java
+++ b/app/src/main/java/com/example/househomey/MainActivity.java
@@ -10,6 +10,8 @@ import androidx.fragment.app.Fragment;
 import com.example.househomey.form.AddItemFragment;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 
 
 /**
@@ -69,4 +71,18 @@ public class MainActivity extends AppCompatActivity {
      * @return A CollectionReference for the current user's items.
      */
     public CollectionReference getItemRef() { return user.getItemRef(); }
+
+    /**
+     * Retrieves a StorageReference to an image in Cloud Storage based on
+     * the current user and the provided image ID.
+     *
+     * @param imageId The unique identifier of the image.
+     * @return A StorageReference pointing to the specified image in Cloud Storage.
+     */
+    public StorageReference getImageRef(String imageId) {
+        return FirebaseStorage.getInstance()
+                .getReference("images/")
+                .child(user.getUsername())
+                .child(imageId);
+    }
 }

--- a/app/src/main/java/com/example/househomey/User.java
+++ b/app/src/main/java/com/example/househomey/User.java
@@ -1,7 +1,6 @@
 package com.example.househomey;
 
 import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 /**
@@ -9,10 +8,8 @@ import com.google.firebase.firestore.FirebaseFirestore;
  * @author Lukas Bonkowski, Owen Cooke
  */
 public class User {
-    private String username;
-    private FirebaseFirestore db;
-    private DocumentReference userRef;
-    private CollectionReference itemRef;
+    private final String username;
+    private final CollectionReference itemRef;
 
     /**
      * This constructs a new user getting references to their firestore information
@@ -20,10 +17,8 @@ public class User {
      *                 item collection
      */
     public User(String username) {
-        db = FirebaseFirestore.getInstance();
         this.username = username;
-        userRef = db.collection("user").document(username);
-        itemRef = userRef.collection("item");
+        itemRef = FirebaseFirestore.getInstance().collection("user/" + username + "/item");
     }
 
     /**
@@ -32,5 +27,13 @@ public class User {
      */
     public CollectionReference getItemRef() {
         return itemRef;
+    }
+
+    /**
+     * Getter for username
+     * @return The user's unique username as a String
+     */
+    public String getUsername() {
+        return username;
     }
 }

--- a/app/src/main/java/com/example/househomey/form/AddItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/AddItemFragment.java
@@ -44,12 +44,8 @@ public class AddItemFragment extends ItemFormFragment {
      * Adds the user input data to a new item in a user's Firestore item collection
      */
     private void addItem() {
-        Item newItem = validateItem("");
+        Item newItem = prepareItem("");
         if (newItem == null) return;
-
-        // Upload new photos (if any) to Cloud Storage
-        photoUris.replaceAll(this::uploadImageToFirebase);
-        newItem.setPhotoIds(photoUris);
 
         // Create new item document in Firestore
         itemRef.add(newItem.getData()).addOnSuccessListener(documentReference -> {

--- a/app/src/main/java/com/example/househomey/form/AddItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/AddItemFragment.java
@@ -47,6 +47,10 @@ public class AddItemFragment extends ItemFormFragment {
         Item newItem = validateItem("");
         if (newItem == null) return;
 
+        // Upload new photos (if any) to Cloud Storage
+        photoUris.replaceAll(this::uploadImageToFirebase);
+        newItem.setPhotoIds(photoUris);
+
         // Create new item document in Firestore
         itemRef.add(newItem.getData()).addOnSuccessListener(documentReference -> {
                     Log.d("Firestore", "Successfully created new item with id:" + documentReference.getId());

--- a/app/src/main/java/com/example/househomey/form/EditItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/EditItemFragment.java
@@ -83,7 +83,7 @@ public class EditItemFragment extends ItemFormFragment {
             // Add image URLs (if any) to the photo gallery adapter
             photoUris.clear();
             photoUris.addAll(item.getPhotoIds());
-            photoAdapter.notifyDataSetChanged();
+            photoAdapter.notifyItemRangeInserted(0, photoUris.size());
         }
     }
 
@@ -91,7 +91,7 @@ public class EditItemFragment extends ItemFormFragment {
      * Edits an existing Item in the user's Firestore item collection.
      */
     private void editItem() {
-        Item updatedItem = validateItem(item.getId());
+        Item updatedItem = prepareItem(item.getId());
         if (updatedItem == null) return;
 
         // Update the existing item document in Firestore

--- a/app/src/main/java/com/example/househomey/form/EditItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/EditItemFragment.java
@@ -79,6 +79,11 @@ public class EditItemFragment extends ItemFormFragment {
             // Set the acquisition Date object and prefill with its formatted text
             dateAcquired = item.getAcquisitionDate();
             ((TextInputEditText) rootView.findViewById(R.id.add_item_date)).setText(formatDate(dateAcquired));
+
+            // Add image URLs (if any) to the photo gallery adapter
+            photoUris.clear();
+            photoUris.addAll(item.getPhotoIds());
+            photoAdapter.notifyDataSetChanged();
         }
     }
 

--- a/app/src/main/java/com/example/househomey/form/EditItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/EditItemFragment.java
@@ -81,7 +81,6 @@ public class EditItemFragment extends ItemFormFragment {
             ((TextInputEditText) rootView.findViewById(R.id.add_item_date)).setText(formatDate(dateAcquired));
 
             // Add image URLs (if any) to the photo gallery adapter
-            photoUris.clear();
             photoUris.addAll(item.getPhotoIds());
             photoAdapter.notifyItemRangeInserted(0, photoUris.size());
         }

--- a/app/src/main/java/com/example/househomey/form/ImagePickerDialog.java
+++ b/app/src/main/java/com/example/househomey/form/ImagePickerDialog.java
@@ -23,19 +23,34 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+/**
+ * A bottom sheet dialog fragment for capturing images from the camera or
+ * selecting them from the user's photo gallery.
+ *
+ * @author Owen Cooke
+ */
 public class ImagePickerDialog extends BottomSheetDialogFragment {
     private ActivityResultLauncher<Intent> pickImageLauncher;
     private boolean fromGallery;
     private OnImagePickedListener onImagePickedListener;
 
+    /**
+     * Sets the listener to receive picked images.
+     *
+     * @param listener The listener to be notified when an image is picked.
+     */
     public void setOnImagePickedListener(OnImagePickedListener listener) {
         this.onImagePickedListener = listener;
     }
 
-    public interface OnImagePickedListener {
-        void onImagePicked(String imageUri);
-    }
-
+    /**
+     * Creates and returns the view hierarchy associated with this dialog.
+     *
+     * @param inflater           The LayoutInflater object that can be used to inflate views.
+     * @param container          If non-null, this is the parent view that the fragment's UI should be attached to.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous saved state as given here.
+     * @return Return the View for the dialog's UI.
+     */
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.dialog_photo_choices, container, false);
@@ -50,6 +65,12 @@ public class ImagePickerDialog extends BottomSheetDialogFragment {
         return rootView;
     }
 
+    /**
+     * Launches an image intent based on the user's choice of from the camera or gallery.
+     *
+     * @param fromGallery A boolean, true if the image should be picked from the gallery,
+     *                    false for if the camera should be opened.
+     */
     private void launchImageIntent(boolean fromGallery) {
         this.fromGallery = fromGallery;
         Intent imageIntent = fromGallery
@@ -58,6 +79,10 @@ public class ImagePickerDialog extends BottomSheetDialogFragment {
         pickImageLauncher.launch(imageIntent);
     }
 
+    /**
+     * Initializes the activity result handler for image capture/picking.
+     * Returns the image's URI to the listener via onImagePicked.
+     */
     private void initImageResultHandler() {
         pickImageLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
             Uri imageUri;
@@ -85,6 +110,13 @@ public class ImagePickerDialog extends BottomSheetDialogFragment {
                 }
             }
         });
+    }
+
+    /**
+     * Interface definition for a callback when an image is picked.
+     */
+    public interface OnImagePickedListener {
+        void onImagePicked(String imageUri);
     }
 }
 

--- a/app/src/main/java/com/example/househomey/form/ImagePickerDialog.java
+++ b/app/src/main/java/com/example/househomey/form/ImagePickerDialog.java
@@ -15,6 +15,7 @@ import android.widget.Button;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.fragment.app.Fragment;
 
 import com.example.househomey.R;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
@@ -35,15 +36,6 @@ public class ImagePickerDialog extends BottomSheetDialogFragment {
     private OnImagePickedListener onImagePickedListener;
 
     /**
-     * Sets the listener to receive picked images.
-     *
-     * @param listener The listener to be notified when an image is picked.
-     */
-    public void setOnImagePickedListener(OnImagePickedListener listener) {
-        this.onImagePickedListener = listener;
-    }
-
-    /**
      * Creates and returns the view hierarchy associated with this dialog.
      *
      * @param inflater           The LayoutInflater object that can be used to inflate views.
@@ -61,6 +53,14 @@ public class ImagePickerDialog extends BottomSheetDialogFragment {
         galleryButton.setOnClickListener(v -> launchImageIntent(true));
         cameraButton.setOnClickListener(v -> launchImageIntent(false));
         initImageResultHandler();
+
+        // Define listener for image result
+        Fragment parent = requireParentFragment();
+        if (parent instanceof OnImagePickedListener) {
+            onImagePickedListener = (OnImagePickedListener) parent;
+        } else {
+            throw new ClassCastException(parent + " must implement OnImagePickedListener");
+        }
 
         return rootView;
     }

--- a/app/src/main/java/com/example/househomey/form/ImagePickerDialog.java
+++ b/app/src/main/java/com/example/househomey/form/ImagePickerDialog.java
@@ -1,0 +1,90 @@
+package com.example.househomey.form;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+
+import com.example.househomey.R;
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class ImagePickerDialog extends BottomSheetDialogFragment {
+    private ActivityResultLauncher<Intent> pickImageLauncher;
+    private boolean fromGallery;
+    private OnImagePickedListener onImagePickedListener;
+
+    public void setOnImagePickedListener(OnImagePickedListener listener) {
+        this.onImagePickedListener = listener;
+    }
+
+    public interface OnImagePickedListener {
+        void onImagePicked(String imageUri);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.dialog_photo_choices, container, false);
+
+        // Set up listeners to open the camera/gallery
+        Button galleryButton = rootView.findViewById(R.id.gallery_button);
+        Button cameraButton = rootView.findViewById(R.id.camera_button);
+        galleryButton.setOnClickListener(v -> launchImageIntent(true));
+        cameraButton.setOnClickListener(v -> launchImageIntent(false));
+        initImageResultHandler();
+
+        return rootView;
+    }
+
+    private void launchImageIntent(boolean fromGallery) {
+        this.fromGallery = fromGallery;
+        Intent imageIntent = fromGallery
+                ? new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+                : new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        pickImageLauncher.launch(imageIntent);
+    }
+
+    private void initImageResultHandler() {
+        pickImageLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+            Uri imageUri;
+            Intent data = result.getData();
+            if (result.getResultCode() == Activity.RESULT_OK && data != null) {
+                if (fromGallery) {
+                    imageUri = data.getData();
+                } else {
+                    // Get bitmap from camera and store in a temp file (to pass a URI for Firebase uploading)
+                    Bitmap imageBitmap = data.getParcelableExtra("data", Bitmap.class);
+                    File storageDir = requireContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+                    File imageFile = null;
+                    try {
+                        imageFile = File.createTempFile("image", ".jpg", storageDir);
+                        FileOutputStream out = new FileOutputStream(imageFile);
+                        imageBitmap.compress(Bitmap.CompressFormat.JPEG, 100, out);
+                    } catch (IOException e) {
+                        Log.e("CAPTURE_IMG_ERR", e.toString());
+                    }
+                    imageUri = Uri.fromFile(imageFile);
+                }
+                // Pass the local image URI via listener
+                if (onImagePickedListener != null && imageUri != null) {
+                    onImagePickedListener.onImagePicked(imageUri.toString());
+                }
+            }
+        });
+    }
+}
+

--- a/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
+++ b/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
@@ -207,14 +207,9 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
      * @param rootView The root view of the fragment.
      */
     private void initAddImageHandler(View rootView) {
-        // Set up adapter for gallery and listener for adding photos
-        photoAdapter = new PhotoAdapter(getContext(), photoUris);
-        ((RecyclerView) rootView.findViewById(R.id.add_photo_grid)).setAdapter(photoAdapter);
-        photoAdapter.setOnAddButtonClickListener(this);
-
-        // Add listener for when image is taken/selected
         imagePickerDialog = new ImagePickerDialog();
-        imagePickerDialog.setOnImagePickedListener(this);
+        photoAdapter = new PhotoAdapter(getContext(), photoUris, this);
+        ((RecyclerView) rootView.findViewById(R.id.add_photo_grid)).setAdapter(photoAdapter);
     }
 
     /**
@@ -222,7 +217,7 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
      */
     @Override
     public void onAddButtonClicked() {
-        imagePickerDialog.show(getParentFragmentManager(), imagePickerDialog.getTag());
+        imagePickerDialog.show(getChildFragmentManager(), imagePickerDialog.getTag());
     }
 
     /**

--- a/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
+++ b/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
@@ -42,10 +42,10 @@ import java.util.UUID;
  */
 public abstract class ItemFormFragment extends Fragment implements ImagePickerDialog.OnImagePickedListener, PhotoAdapter.OnAddButtonClickListener {
     protected Date dateAcquired;
-    private TextInputEditText dateTextView;
     protected CollectionReference itemRef;
     protected ArrayList<String> photoUris = new ArrayList<>();
     protected PhotoAdapter photoAdapter;
+    private TextInputEditText dateTextView;
     private ImagePickerDialog imagePickerDialog;
 
     /**
@@ -147,7 +147,7 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
         dateTextView = rootView.findViewById(R.id.add_item_date);
 
         MaterialDatePicker<Long> datePicker = createDatePicker();
-        
+
         datePicker.addOnPositiveButtonClickListener(selection -> {
             dateAcquired = new Date(selection);
             dateTextView.setText(datePicker.getHeaderText());
@@ -200,6 +200,12 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
         });
     }
 
+    /**
+     * Initializes photo components for the fragment (photo adapter,
+     * and image picker dialog) as well as sets this fragment to the components' listeners.
+     *
+     * @param rootView The root view of the fragment.
+     */
     private void initAddImageHandler(View rootView) {
         // Set up adapter for gallery and listener for adding photos
         photoAdapter = new PhotoAdapter(getContext(), photoUris);
@@ -211,11 +217,19 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
         imagePickerDialog.setOnImagePickedListener(this);
     }
 
+    /**
+     * Callback method for when the Add button in the photo gallery is clicked.
+     */
     @Override
     public void onAddButtonClicked() {
         imagePickerDialog.show(getParentFragmentManager(), imagePickerDialog.getTag());
     }
 
+    /**
+     * Callback method for handling the image URI returned from image picker dialog.
+     *
+     * @param imageUri The URI of the selected/taken image.
+     */
     @Override
     public void onImagePicked(String imageUri) {
         imagePickerDialog.dismiss();
@@ -223,6 +237,12 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
         photoAdapter.notifyItemInserted(photoAdapter.getItemCount() - 1);
     }
 
+    /**
+     * Uploads a local image to Firebase Cloud Storage and returns its UUID.
+     *
+     * @param imageUri The local URI of the image to be uploaded.
+     * @return The UUID of the uploaded image.
+     */
     private String uploadImageToFirebase(String imageUri) {
         if (imageUri.contains("content://") || imageUri.contains("file://")) {
             // New image to upload, create a unique storage reference

--- a/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
+++ b/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
@@ -40,7 +40,7 @@ import java.util.UUID;
  *
  * @author Owen Cooke
  */
-public abstract class ItemFormFragment extends Fragment implements ImagePickerDialog.OnImagePickedListener {
+public abstract class ItemFormFragment extends Fragment implements ImagePickerDialog.OnImagePickedListener, PhotoAdapter.OnAddButtonClickListener {
     protected Date dateAcquired;
     private TextInputEditText dateTextView;
     protected CollectionReference itemRef;
@@ -201,15 +201,19 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
     }
 
     private void initAddImageHandler(View rootView) {
-        // Set up adapter for gallery RecyclerView
+        // Set up adapter for gallery and listener for adding photos
         photoAdapter = new PhotoAdapter(getContext(), photoUris);
         ((RecyclerView) rootView.findViewById(R.id.add_photo_grid)).setAdapter(photoAdapter);
+        photoAdapter.setOnAddButtonClickListener(this);
 
-        // Add listeners for photo adding
+        // Add listener for when image is taken/selected
         imagePickerDialog = new ImagePickerDialog();
         imagePickerDialog.setOnImagePickedListener(this);
-        rootView.findViewById(R.id.add_photo_button)
-                .setOnClickListener(v -> imagePickerDialog.show(getParentFragmentManager(), imagePickerDialog.getTag()));
+    }
+
+    @Override
+    public void onAddButtonClicked() {
+        imagePickerDialog.show(getParentFragmentManager(), imagePickerDialog.getTag());
     }
 
     @Override

--- a/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
+++ b/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
@@ -24,7 +24,6 @@ import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 
 import java.math.BigDecimal;
@@ -242,7 +241,7 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
         if (imageUri.contains("content://") || imageUri.contains("file://")) {
             // New image to upload, create a unique storage reference
             String imageId = UUID.randomUUID().toString();
-            StorageReference imageRef = FirebaseStorage.getInstance().getReference().child("images/" + imageId);
+            StorageReference imageRef = ((MainActivity) requireActivity()).getImageRef(imageId);
 
             // Upload the image to Cloud Storage
             imageRef.putFile(Uri.parse(imageUri))
@@ -250,7 +249,7 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
                     .addOnFailureListener(e -> Log.e("IMAGE_UPLOAD", "Failed to upload image: " + e));
             return imageId;
         }
-        // Already uploaded to Firebase / is a unique ID
+        // Already uploaded to Firebase
         return imageUri;
     }
 }

--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -28,7 +28,7 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private static final int VIEW_TYPE_IMAGE = 1;
     private final Context context;
     private final List<String> imageUris;
-    private OnAddButtonClickListener onAddButtonClickListener;
+    private final OnAddButtonClickListener onAddButtonClickListener;
 
     /**
      * Constructs a PhotoAdapter with the given context and a list of image URIs to display.
@@ -36,17 +36,9 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
      * @param context   The context.
      * @param imageUris The list of image URIs.
      */
-    public PhotoAdapter(Context context, List<String> imageUris) {
+    public PhotoAdapter(Context context, List<String> imageUris, OnAddButtonClickListener listener) {
         this.context = context;
         this.imageUris = imageUris;
-    }
-
-    /**
-     * Sets a listener for the add photo button click event.
-     *
-     * @param listener The listener to be notified when the add button is clicked.
-     */
-    public void setOnAddButtonClickListener(OnAddButtonClickListener listener) {
         this.onAddButtonClickListener = listener;
     }
 

--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -37,8 +37,8 @@ public class PhotoAdapter extends RecyclerView.Adapter<PhotoAdapter.ViewHolder> 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         String imagePath = imageUris.get(position);
-        if (imagePath.contains("content")) {
-            // Local file URI, use directly
+        if (imagePath.contains("content://") || imagePath.contains("file://")) {
+            // Local file URI, load directly
             Glide.with(context)
                     .load(imagePath)
                     .diskCacheStrategy(DiskCacheStrategy.DATA)

--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -13,9 +13,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.example.househomey.MainActivity;
 import com.example.househomey.R;
-import com.google.firebase.storage.FirebaseStorage;
-import com.google.firebase.storage.StorageReference;
 
 import java.util.List;
 
@@ -91,10 +90,8 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             // Local file URI, load directly
             requestBuilder.load(imagePath);
         } else {
-            // Cloud Storage URI, create a Firebase reference and fetch
-            imagePath = "images/" + imagePath;
-            StorageReference storageReference = FirebaseStorage.getInstance().getReference(imagePath);
-            requestBuilder.load(storageReference);
+            // Cloud Storage URI, fetch from Firebase
+            requestBuilder.load(((MainActivity) context).getImageRef(imagePath));
         }
         requestBuilder.diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
     }

--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -17,52 +17,72 @@ import com.google.firebase.storage.StorageReference;
 
 import java.util.List;
 
-public class PhotoAdapter extends RecyclerView.Adapter<PhotoAdapter.ViewHolder> {
-
-    private Context context;
-    private List<String> imageUris;
+public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private static final int VIEW_TYPE_IMAGE = 1;
+    private final Context context;
+    private final List<String> imageUris;
+    private OnAddButtonClickListener onAddButtonClickListener;
 
     public PhotoAdapter(Context context, List<String> imageUris) {
         this.context = context;
         this.imageUris = imageUris;
     }
 
+    public void setOnAddButtonClickListener(OnAddButtonClickListener listener) {
+        this.onAddButtonClickListener = listener;
+    }
+
     @NonNull
     @Override
-    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.gallery_photo, parent, false);
-        return new ViewHolder(view);
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        if (viewType == VIEW_TYPE_IMAGE) {
+            View view = inflater.inflate(R.layout.gallery_photo, parent, false);
+            return new ImageViewHolder(view);
+        }
+        View view = inflater.inflate(R.layout.add_photo_button, parent, false);
+        return new RecyclerView.ViewHolder(view) {};
     }
 
     @Override
-    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        String imagePath = imageUris.get(position);
-        if (imagePath.contains("content://") || imagePath.contains("file://")) {
-            // Local file URI, load directly
-            Glide.with(context)
-                    .load(imagePath)
-                    .diskCacheStrategy(DiskCacheStrategy.DATA)
-                    .into(holder.imageView);
-        } else {
-            // Cloud Storage URI, create a Firebase reference and fetch
-            imagePath = "images/" + imageUris.get(position);
-            StorageReference storageReference = FirebaseStorage.getInstance().getReference(imagePath);
-            Glide.with(context)
-                    .load(storageReference)
-                    .diskCacheStrategy(DiskCacheStrategy.DATA)
-                    .into(holder.imageView);
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        if (holder instanceof ImageViewHolder) {
+            ImageView imageView = ((ImageViewHolder) holder).imageView;
+            String imagePath = imageUris.get(position);
+            if (imagePath.contains("content://") || imagePath.contains("file://")) {
+                // Local file URI, so just load directly
+                Glide.with(context).load(imagePath).diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
+            } else {
+                // Cloud Storage URI, so create a Firebase reference and fetch
+                imagePath = "images/" + imageUris.get(position);
+                StorageReference storageReference = FirebaseStorage.getInstance().getReference(imagePath);
+                Glide.with(context).load(storageReference).diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
+            }
+        }
+        else {
+            holder.itemView.setOnClickListener(v -> onAddButtonClickListener.onAddButtonClicked());
         }
     }
 
     @Override
     public int getItemCount() {
-        return imageUris.size();
+        // Add 1 to account for Add button always at the end
+        return imageUris.size() + 1;
     }
 
-    public static class ViewHolder extends RecyclerView.ViewHolder {
+    @Override
+    public int getItemViewType(int position) {
+        return (position == imageUris.size()) ? 0 : VIEW_TYPE_IMAGE;
+    }
+
+    public interface OnAddButtonClickListener {
+        void onAddButtonClicked();
+    }
+
+    public static class ImageViewHolder extends RecyclerView.ViewHolder {
         ImageView imageView;
 
-        public ViewHolder(@NonNull View itemView) {
+        public ImageViewHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.gallery_image_view);
         }

--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -1,6 +1,7 @@
 package com.example.househomey.form;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.example.househomey.R;
 import com.google.firebase.storage.FirebaseStorage;
@@ -17,21 +19,44 @@ import com.google.firebase.storage.StorageReference;
 
 import java.util.List;
 
+/**
+ * Custom adapter for displaying and adding photos to a RecyclerView.
+ *
+ * @author Owen Cooke
+ */
 public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private static final int VIEW_TYPE_IMAGE = 1;
     private final Context context;
     private final List<String> imageUris;
     private OnAddButtonClickListener onAddButtonClickListener;
 
+    /**
+     * Constructs a PhotoAdapter with the given context and a list of image URIs to display.
+     *
+     * @param context   The context.
+     * @param imageUris The list of image URIs.
+     */
     public PhotoAdapter(Context context, List<String> imageUris) {
         this.context = context;
         this.imageUris = imageUris;
     }
 
+    /**
+     * Sets a listener for the add photo button click event.
+     *
+     * @param listener The listener to be notified when the add button is clicked.
+     */
     public void setOnAddButtonClickListener(OnAddButtonClickListener listener) {
         this.onAddButtonClickListener = listener;
     }
 
+    /**
+     * Creates new view holders for the RecyclerView based on their view type.
+     *
+     * @param parent   The ViewGroup into which the new View will be added after it is bound to an adapter position.
+     * @param viewType The view type of the new View.
+     * @return A new ViewHolder that holds a View of the given view type.
+     */
     @NonNull
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -41,47 +66,88 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             return new ImageViewHolder(view);
         }
         View view = inflater.inflate(R.layout.add_photo_button, parent, false);
-        return new RecyclerView.ViewHolder(view) {};
+        return new RecyclerView.ViewHolder(view) {
+        };
     }
 
+    /**
+     * Called by RecyclerView to display the data at the specified position.
+     * Required for loading the URI at position into the actual ImageView.
+     * Also binds the click handler for the add button.
+     *
+     * @param holder   The ViewHolder that should be updated to represent the contents of the item at the given position.
+     * @param position The position of the item within the adapter's data set.
+     */
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof ImageViewHolder) {
-            ImageView imageView = ((ImageViewHolder) holder).imageView;
-            String imagePath = imageUris.get(position);
-            if (imagePath.contains("content://") || imagePath.contains("file://")) {
-                // Local file URI, so just load directly
-                Glide.with(context).load(imagePath).diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
-            } else {
-                // Cloud Storage URI, so create a Firebase reference and fetch
-                imagePath = "images/" + imageUris.get(position);
-                StorageReference storageReference = FirebaseStorage.getInstance().getReference(imagePath);
-                Glide.with(context).load(storageReference).diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
-            }
-        }
-        else {
+            loadIntoImageView(((ImageViewHolder) holder).imageView, imageUris.get(position));
+        } else {
             holder.itemView.setOnClickListener(v -> onAddButtonClickListener.onAddButtonClicked());
         }
     }
 
+    /**
+     * Loads the image defined by a URI into an ImageView using Glide.
+     *
+     * @param imageView The ImageView to load the image into.
+     * @param imagePath The string URI of the image.
+     */
+    private void loadIntoImageView(ImageView imageView, String imagePath) {
+        RequestBuilder<Drawable> requestBuilder = Glide.with(context).asDrawable();
+        if (imagePath.contains("content://") || imagePath.contains("file://")) {
+            // Local file URI, load directly
+            requestBuilder.load(imagePath);
+        } else {
+            // Cloud Storage URI, create a Firebase reference and fetch
+            imagePath = "images/" + imagePath;
+            StorageReference storageReference = FirebaseStorage.getInstance().getReference(imagePath);
+            requestBuilder.load(storageReference);
+        }
+        requestBuilder.diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
+    }
+
+    /**
+     * Getter for the number of items held by the adapter.
+     * Add 1 to the total to account for the Add Button, which is always at the end of the adapter.
+     *
+     * @return The total number of items in this adapter.
+     */
     @Override
     public int getItemCount() {
-        // Add 1 to account for Add button always at the end
         return imageUris.size() + 1;
     }
 
+    /**
+     * Return the view type of the item at position for the purposes of view recycling.
+     * All Views handled as image types, except the last element, which is the add button.
+     *
+     * @param position – position to query
+     * @return integer value identifying the type of the view needed to represent the item at position.
+     */
     @Override
     public int getItemViewType(int position) {
         return (position == imageUris.size()) ? 0 : VIEW_TYPE_IMAGE;
     }
 
+    /**
+     * Interface for a callback when the add button is clicked.
+     */
     public interface OnAddButtonClickListener {
         void onAddButtonClicked();
     }
 
+    /**
+     * ViewHolder for displaying images in the RecyclerView.
+     */
     public static class ImageViewHolder extends RecyclerView.ViewHolder {
         ImageView imageView;
 
+        /**
+         * Constructs an ImageViewHolder using the given itemView.
+         *
+         * @param itemView The view for this ViewHolder.
+         */
         public ImageViewHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.gallery_image_view);

--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -1,0 +1,70 @@
+package com.example.househomey.form;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.example.househomey.R;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+
+import java.util.List;
+
+public class PhotoAdapter extends RecyclerView.Adapter<PhotoAdapter.ViewHolder> {
+
+    private Context context;
+    private List<String> imageUris;
+
+    public PhotoAdapter(Context context, List<String> imageUris) {
+        this.context = context;
+        this.imageUris = imageUris;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.gallery_photo, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        String imagePath = imageUris.get(position);
+        if (imagePath.contains("content")) {
+            // Local file URI, use directly
+            Glide.with(context)
+                    .load(imagePath)
+                    .diskCacheStrategy(DiskCacheStrategy.DATA)
+                    .into(holder.imageView);
+        } else {
+            // Cloud Storage URI, create a Firebase reference and fetch
+            imagePath = "images/" + imageUris.get(position);
+            StorageReference storageReference = FirebaseStorage.getInstance().getReference(imagePath);
+            Glide.with(context)
+                    .load(storageReference)
+                    .diskCacheStrategy(DiskCacheStrategy.DATA)
+                    .into(holder.imageView);
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return imageUris.size();
+    }
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        ImageView imageView;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            imageView = itemView.findViewById(R.id.gallery_image_view);
+        }
+    }
+}

--- a/app/src/main/java/com/example/househomey/utils/FirebaseImageRegistry.java
+++ b/app/src/main/java/com/example/househomey/utils/FirebaseImageRegistry.java
@@ -1,0 +1,39 @@
+package com.example.househomey.utils;
+
+import android.content.Context;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.Registry;
+import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.module.AppGlideModule;
+import com.firebase.ui.storage.images.FirebaseImageLoader;
+import com.google.firebase.storage.StorageReference;
+
+import java.io.InputStream;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Required for loading Firebase Cloud Storage images directly into ImageViews using Glide.
+ * It registers the {@link com.firebase.ui.storage.images.FirebaseImageLoader} to handle StorageReference objects.
+ * Reference: https://github.com/firebase/FirebaseUI-Android/blob/master/app/src/main/java/com/firebase/uidemo/storage/MyAppGlideModule.java
+ */
+@GlideModule
+public class FirebaseImageRegistry extends AppGlideModule {
+
+    /**
+     * Registers components needed for loading images from Firebase Cloud Storage using Glide.
+     *
+     * @param context  The application context.
+     * @param glide    The Glide instance.
+     * @param registry The Glide registry to register components.
+     */
+    @Override
+    public void registerComponents(@NonNull Context context,
+                                   @NonNull Glide glide,
+                                   @NonNull Registry registry) {
+        // Register FirebaseImageLoader to handle StorageReference
+        registry.append(StorageReference.class, InputStream.class,
+                new FirebaseImageLoader.Factory());
+    }
+}

--- a/app/src/main/res/drawable/baseline_add_32.xml
+++ b/app/src/main/res/drawable/baseline_add_32.xml
@@ -1,0 +1,5 @@
+<vector android:height="32dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_camera_alt_24.xml
+++ b/app/src/main/res/drawable/baseline_camera_alt_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path android:fillColor="@android:color/white" android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_insert_photo_24.xml
+++ b/app/src/main/res/drawable/baseline_insert_photo_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/layout/add_photo_button.xml
+++ b/app/src/main/res/layout/add_photo_button.xml
@@ -1,0 +1,10 @@
+<com.google.android.material.imageview.ShapeableImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="78dp"
+    android:layout_height="78dp"
+    android:layout_marginBottom="10dp"
+    android:background="#EBE0C4"
+    android:scaleType="centerInside"
+    android:src="@drawable/baseline_add_32"
+    android:tint="@color/black"
+    app:shapeAppearanceOverlay="@style/roundedImageView" />

--- a/app/src/main/res/layout/dialog_photo_choices.xml
+++ b/app/src/main/res/layout/dialog_photo_choices.xml
@@ -1,0 +1,41 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/brown"
+    android:orientation="vertical"
+    android:paddingVertical="4dp">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/camera_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="24dp"
+        android:text="Take photo"
+        android:textAlignment="textStart"
+        android:textColor="@color/white"
+        app:icon="@drawable/baseline_camera_alt_24"
+        app:iconGravity="textStart"
+        app:iconSize="24dp"
+        app:iconTint="@color/white" />
+
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_marginVertical="4dp"
+        app:dividerColor="@color/white" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/gallery_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="24dp"
+        android:text="Select from gallery"
+        android:textAlignment="textStart"
+        android:textColor="@color/white"
+        app:icon="@drawable/baseline_insert_photo_24"
+        app:iconGravity="textStart"
+        app:iconSize="24dp"
+        app:iconTint="@color/white" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -138,6 +138,37 @@
                 android:layout_width="match_parent"
                 android:layout_height="16dp" />
 
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:text="Add Photos"
+                android:textColor="@color/black"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/add_photo_button"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="32dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                app:icon="@drawable/baseline_add_24"
+                app:iconGravity="textStart"
+                app:iconPadding="0dp"
+                app:iconSize="32dp"
+                app:iconTint="@color/black" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/add_photo_grid"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:spanCount="4" />
+
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/TextInputLayoutStyle"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -148,18 +148,9 @@
                 android:textSize="16sp"
                 android:textStyle="bold" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/add_photo_button"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="32dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                app:icon="@drawable/baseline_add_24"
-                app:iconGravity="textStart"
-                app:iconPadding="0dp"
-                app:iconSize="32dp"
-                app:iconTint="@color/black" />
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="8dp" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/add_photo_grid"
@@ -168,6 +159,10 @@
                 android:layout_gravity="center"
                 app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                 app:spanCount="4" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="6dp" />
 
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/TextInputLayoutStyle"

--- a/app/src/main/res/layout/gallery_photo.xml
+++ b/app/src/main/res/layout/gallery_photo.xml
@@ -1,0 +1,9 @@
+<com.google.android.material.imageview.ShapeableImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:shapeAppearanceOverlay="@style/roundedImageView"
+    android:id="@+id/gallery_image_view"
+    android:layout_width="78dp"
+    android:layout_height="78dp"
+    android:layout_marginBottom="10dp"
+    android:scaleType="centerCrop" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,5 +19,10 @@
         <item name="android:color">#40FFFFFF</item>
     </style>
 
+    <style name="roundedImageView" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">8dp</item>
+    </style>
+
     <style name="Theme.HouseHomey" parent="Base.Theme.HouseHomey" />
 </resources>


### PR DESCRIPTION
### Describe your changes

This PR accomplishes the following:

- allows users to add photos to their item in the Add Item fragment
- prefills Edit Item fragment with existing photos and allows users to add more
- can add from camera or photo gallery, via a new dialog popup for selecting one of the options

Implementation Notes:
- photos are stored in Firebase Cloud Storage, which is a separate page from Firestore. See [here](https://console.firebase.google.com/u/0/project/househomey-2f443/storage/househomey-2f443.appspot.com/files/~2Fimages)
- all images in Cloud Storage are stored under a single root folder "/images"
- each image's filename is a UUID
- each Item document (in Firestore) will have an array field "photoIds", where each item in the array is the string UUID of its respective images in Cloud Storage

### Issue ticket number and link

This PR addresses: https://github.com/CMPUT301F23T08/HouseHomey/issues/9

### Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] Necessary java docs are present
- [X] Necessary UML diagrams are created
- [ ] Necessary tests are written

### Screenshots (if applicable)
<img src="https://github.com/CMPUT301F23T08/HouseHomey/assets/90405643/5fcf5e1a-7782-4e05-8cb4-250deaf9405a" width=250>

![HouseHomey - PART4 (ACTIVE)](https://github.com/CMPUT301F23T08/HouseHomey/assets/90405643/b173a2bd-0f66-45a3-a350-2b1396f415a0)
