### PR TITLE
[BUG] Make photo grid adjust column count based on screen width

### DIFF
--- a/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
+++ b/app/src/main/java/com/example/househomey/form/PhotoAdapter.java
@@ -4,12 +4,15 @@ import static com.example.househomey.utils.FragmentUtils.isValidUUID;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -19,6 +22,7 @@ import com.example.househomey.MainActivity;
 import com.example.househomey.R;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Custom adapter for displaying and adding photos to a RecyclerView.
@@ -26,6 +30,7 @@ import java.util.List;
  * @author Owen Cooke
  */
 public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private static final int HOLDER_SIZE_DP = 87;
     private static final int VIEW_TYPE_IMAGE = 1;
     private final Context context;
     private final List<String> imageUris;
@@ -44,6 +49,18 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     /**
+     * Called when this adapter is attached to a RecyclerView.
+     * Makes a call to adjust the column count within the RecyclerView
+     *
+     * @param recyclerView The RecyclerView to which this adapter is attached.
+     */
+    @Override
+    public void onAttachedToRecyclerView(@NonNull RecyclerView recyclerView) {
+        super.onAttachedToRecyclerView(recyclerView);
+        setColumnCount(recyclerView);
+    }
+
+    /**
      * Creates new view holders for the RecyclerView based on their view type.
      *
      * @param parent   The ViewGroup into which the new View will be added after it is bound to an adapter position.
@@ -53,14 +70,15 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     @NonNull
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
-        if (viewType == VIEW_TYPE_IMAGE) {
-            View view = inflater.inflate(R.layout.gallery_photo_with_delete, parent, false);
-            return new ImageViewHolder(view);
-        }
-        View view = inflater.inflate(R.layout.add_photo_button, parent, false);
-        return new RecyclerView.ViewHolder(view) {
-        };
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate((viewType == VIEW_TYPE_IMAGE) ?
+                        R.layout.gallery_photo_with_delete :
+                        R.layout.add_photo_button, parent, false);
+        resizeViews(view, viewType);
+        return (viewType == VIEW_TYPE_IMAGE) ?
+                new ImageViewHolder(view) :
+                new RecyclerView.ViewHolder(view) {
+                };
     }
 
     /**
@@ -74,29 +92,12 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof ImageViewHolder) {
-            loadIntoImageView(((ImageViewHolder) holder).imageView, imageUris.get(position));
-            holder.itemView.findViewById(R.id.delete_photo_button).setOnClickListener(v -> onButtonClickListener.onDeleteButtonClicked(holder.getAdapterPosition()));
+            ImageViewHolder viewHolder = (ImageViewHolder) holder;
+            loadIntoImageView(viewHolder.imageView, imageUris.get(position));
+            viewHolder.deleteButton.setOnClickListener(v -> onButtonClickListener.onDeleteButtonClicked(holder.getAdapterPosition()));
         } else {
             holder.itemView.setOnClickListener(v -> onButtonClickListener.onAddButtonClicked());
         }
-    }
-
-    /**
-     * Loads the image defined by a URI into an ImageView using Glide.
-     *
-     * @param imageView The ImageView to load the image into.
-     * @param imagePath The string URI of the image.
-     */
-    private void loadIntoImageView(ImageView imageView, String imagePath) {
-        RequestBuilder<Drawable> requestBuilder = Glide.with(context).asDrawable();
-        if (isValidUUID(imagePath)) {
-            // Cloud Storage UUID, fetch from Firebase
-            requestBuilder.load(((MainActivity) context).getImageRef(imagePath));
-        } else {
-            // Local file URI, load directly
-            requestBuilder.load(imagePath);
-        }
-        requestBuilder.diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
     }
 
     /**
@@ -123,10 +124,75 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     /**
+     * Loads the image defined by a URI into an ImageView using Glide.
+     *
+     * @param imageView The ImageView to load the image into.
+     * @param imagePath The string URI of the image.
+     */
+    private void loadIntoImageView(ImageView imageView, String imagePath) {
+        RequestBuilder<Drawable> requestBuilder = Glide.with(context).asDrawable();
+        if (isValidUUID(imagePath)) {
+            // Cloud Storage UUID, fetch from Firebase
+            requestBuilder.load(((MainActivity) context).getImageRef(imagePath));
+        } else {
+            // Local file URI, load directly
+            requestBuilder.load(imagePath);
+        }
+        requestBuilder.diskCacheStrategy(DiskCacheStrategy.DATA).into(imageView);
+    }
+
+    /**
+     * Adjusts the column count of the associated GridLayoutManager based on the screen size.
+     * Ensures images don't overlap each other in the rows.
+     *
+     * @param recyclerView The RecyclerView to which this adapter is attached.
+     */
+    private void setColumnCount(RecyclerView recyclerView) {
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        float dpWidth = displayMetrics.widthPixels / displayMetrics.density;
+        int spanCount = Math.max((int) (dpWidth / HOLDER_SIZE_DP), 1);
+        GridLayoutManager layoutManager = (GridLayoutManager) recyclerView.getLayoutManager();
+        Objects.requireNonNull(layoutManager).setSpanCount(spanCount);
+    }
+
+    /**
+     * Resizes the given parent container view and its inner elements.
+     * Used to align the delete image button to the top right corner of an image.
+     *
+     * @param view     The parent view containing the views to be resized.
+     * @param viewType The type of the view, used to determine which type of view to resize.
+     */
+    private void resizeViews(View view, int viewType) {
+        // Set the size of the holder (which contains the image and delete button)
+        int holderSize = (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                HOLDER_SIZE_DP,
+                view.getContext().getResources().getDisplayMetrics()
+        );
+        ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+        layoutParams.width = holderSize;
+        layoutParams.height = holderSize;
+        view.setLayoutParams(layoutParams);
+
+        // Set the size of the image (and add button block)
+        int photoSize = (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                HOLDER_SIZE_DP - 9,
+                view.getContext().getResources().getDisplayMetrics()
+        );
+        ImageView imageView = view.findViewById((viewType == VIEW_TYPE_IMAGE) ? R.id.gallery_image_view : R.id.add_photo_button);
+        ViewGroup.LayoutParams photoLayoutParams = imageView.getLayoutParams();
+        photoLayoutParams.width = photoSize;
+        photoLayoutParams.height = photoSize;
+        imageView.setLayoutParams(photoLayoutParams);
+    }
+
+    /**
      * Interface for callbacks when buttons within the photo adapter are clicked.
      */
     public interface OnButtonClickListener {
         void onAddButtonClicked();
+
         void onDeleteButtonClicked(int position);
     }
 
@@ -135,6 +201,7 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
      */
     public static class ImageViewHolder extends RecyclerView.ViewHolder {
         ImageView imageView;
+        ImageView deleteButton;
 
         /**
          * Constructs an ImageViewHolder using the given itemView.
@@ -144,6 +211,7 @@ public class PhotoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         public ImageViewHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.gallery_image_view);
+            deleteButton = itemView.findViewById(R.id.delete_photo_button);
         }
     }
 }

--- a/app/src/main/res/layout/add_photo_button.xml
+++ b/app/src/main/res/layout/add_photo_button.xml
@@ -1,13 +1,13 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="87dp"
-    android:layout_height="87dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:layout_marginBottom="10dp">
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/add_photo_button"
-        android:layout_width="78dp"
-        android:layout_height="78dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignParentBottom="true"
         android:background="#EBE0C4"

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -155,8 +155,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                app:spanCount="4" />
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager" />
 
             <Space
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/gallery_photo_with_delete.xml
+++ b/app/src/main/res/layout/gallery_photo_with_delete.xml
@@ -1,11 +1,11 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="87dp"
-    android:layout_height="87dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:layout_marginBottom="10dp">
 
     <include layout="@layout/gallery_photo"
-        android:layout_width="78dp"
-        android:layout_height="78dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignParentBottom="true"
         android:layout_marginBottom="0dp" />


### PR DESCRIPTION
Changes to address the `deleteExistingPhoto` test failing on the CI / for small device screens:
- add a method to increase/reduce the number of photo grid columns depending on screen size
- removed all the hardcoded `dp` sizing in the associated XML components, opting to set the size within the Java component instead
- the failing test passes upon these changes 🟢 

![image](https://github.com/CMPUT301F23T08/HouseHomey/assets/90405643/03c59273-ab86-4a86-ad62-b244081a49ac)
