### PR TITLE
Clear button to clear fields on add item fragment

### DIFF
--- a/app/src/main/java/com/example/househomey/form/AddItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/AddItemFragment.java
@@ -46,6 +46,14 @@ public class AddItemFragment extends ItemFormFragment {
         initTextValidators(rootView);
         rootView.findViewById(R.id.add_item_back_button).setVisibility(View.GONE);
         rootView.findViewById(R.id.add_item_confirm_button).setOnClickListener(v -> addItem());
+        View clearButton = rootView.findViewById(R.id.add_item_clear_button);
+        clearButton.setVisibility(View.VISIBLE);
+        clearButton.setOnClickListener(v -> {
+            clearDataFields();
+            ((TextInputLayout) getView().findViewById(R.id.add_item_description_layout)).setError(null);
+            ((TextInputLayout) getView().findViewById(R.id.add_item_cost_layout)).setError(null);
+            ((TextInputLayout) getView().findViewById(R.id.add_item_date_layout)).setError(null);
+        });
         return rootView;
     }
 

--- a/app/src/main/res/layout/fragment_add_item.xml
+++ b/app/src/main/res/layout/fragment_add_item.xml
@@ -251,6 +251,24 @@
                     android:maxLength="280" />
             </com.google.android.material.textfield.TextInputLayout>
 
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="16dp" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/add_item_clear_button"
+                android:layout_width="125dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/delete_button_border"
+                android:layout_gravity="center"
+                android:text="Clear All"
+                android:paddingVertical="10dp"
+                android:paddingHorizontal="24dp"
+                android:textAllCaps="false"
+                android:textColor="@color/red"
+                android:visibility="gone">
+            </androidx.appcompat.widget.AppCompatButton>
+
         </LinearLayout>
 
     </ScrollView>


### PR DESCRIPTION
### Describe your changes

This PR accomplishes the following:

- Adds a clear button to the Add Item page
- Clicking on it clears any text fields filled or photos added. Any edit text errors are set to null.

### Issue ticket number and link

This PR addresses: #<link_to_issue>

### Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Necessary java docs are present
- [ ] Necessary UML diagrams are created
- [ ] Necessary tests are written

### Screenshots (if applicable)

e.g. UI screenshots, UML screenshots, etc