### PR TITLE
[BUGFIX] Fix edit photos crashing with new navigation method

### DIFF
--- a/app/src/main/java/com/example/househomey/form/EditItemFragment.java
+++ b/app/src/main/java/com/example/househomey/form/EditItemFragment.java
@@ -2,6 +2,7 @@ package com.example.househomey.form;
 
 import static com.example.househomey.utils.FragmentUtils.formatDate;
 import static com.example.househomey.utils.FragmentUtils.goBack;
+import static java.util.Optional.ofNullable;
 
 import android.os.Bundle;
 import android.util.Log;
@@ -27,12 +28,7 @@ import java.io.Serializable;
 public class EditItemFragment extends ItemFormFragment {
     private Item item;
     private Item updatedItem;
-
     private OnItemUpdateListener listener;
-    public interface OnItemUpdateListener extends Serializable {
-        void onItemUpdated(Item updatedItem);
-    }
-
 
     /**
      * This creates the view to edit an existing item and sets the button listeners.
@@ -49,18 +45,13 @@ public class EditItemFragment extends ItemFormFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View rootView = super.onCreateView(inflater, container, savedInstanceState);
-
-        //Get the item and listener for item update from Bundle
-        Bundle args = getArguments();
-        assert(args!=null);
-        this.item = BundleCompat.getParcelable(args, "item", Item.class);
-        this.listener = args.getSerializable("listener", OnItemUpdateListener.class);
+        ofNullable(getArguments())
+                .map(args -> BundleCompat.getParcelable(args, "item", Item.class))
+                .ifPresent(item -> this.item = item);
 
         // Change title and prefill inputs with the existing Item's data
         ((MaterialTextView) rootView.findViewById(R.id.add_item_title)).setText("Edit Item");
         prefillInputs(rootView);
-
-
 
         // Add listeners for buttons and text validation
         initDatePicker(rootView);
@@ -128,9 +119,22 @@ public class EditItemFragment extends ItemFormFragment {
      * Sends the new item to the view item fragment
      */
     private void sendItem() {
-        if (listener!=null) {
+        if (listener != null) {
             listener.onItemUpdated(updatedItem);
         }
         goBack(getContext());
+    }
+
+    /**
+     * Sets the listener for item update events.
+     *
+     * @param listener The listener to be notified when an item is updated.
+     */
+    public void setListener(OnItemUpdateListener listener) {
+        this.listener = listener;
+    }
+
+    public interface OnItemUpdateListener extends Serializable {
+        void onItemUpdated(Item updatedItem);
     }
 }

--- a/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
+++ b/app/src/main/java/com/example/househomey/form/ItemFormFragment.java
@@ -376,7 +376,6 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
      * Clears all the text fields and the photos in the form
      */
     protected void clearDataFields() {
-
         View formView = getView();
         int numUris = photoUris.size();
         photoUris.clear();
@@ -388,8 +387,5 @@ public abstract class ItemFormFragment extends Fragment implements ImagePickerDi
         ((EditText) formView.findViewById(R.id.add_item_model)).setText("");
         ((EditText) formView.findViewById(R.id.add_item_serial_number)).setText("");
         ((EditText) formView.findViewById(R.id.add_item_comment)).setText("");
-
-
-
     }
 }

--- a/app/src/main/java/com/example/househomey/item/ViewItemFragment.java
+++ b/app/src/main/java/com/example/househomey/item/ViewItemFragment.java
@@ -21,12 +21,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.example.househomey.MainActivity;
 import com.example.househomey.R;
 import com.example.househomey.form.EditItemFragment;
-
 import com.example.househomey.form.ViewPhotoAdapter;
-import com.example.househomey.home.HomeFragment;
-import com.example.househomey.item.Item;
-import com.example.househomey.tags.Tag;
 import com.example.househomey.tags.ApplyTagFragment;
+import com.example.househomey.tags.Tag;
 import com.example.househomey.utils.FragmentUtils;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
@@ -43,32 +40,31 @@ import java.util.Objects;
 /**
  * This fragment is for the "View Item Page" - which currently displays the details and comment linked
  * to the item
+ *
  * @author Matthew Neufeld
  */
-public class ViewItemFragment extends Fragment implements EditItemFragment.OnItemUpdateListener{
-    private Item item;
+public class ViewItemFragment extends Fragment implements EditItemFragment.OnItemUpdateListener {
     protected ViewPhotoAdapter viewPhotoAdapter;
-    private CollectionReference tagRef;
+    private Item item;
     private ChipGroup chipGroup;
     private ListenerRegistration tagListener;
 
     /**
-     *
-     * @param inflater The LayoutInflater object that can be used to inflate
-     * any views in the fragment,
-     * @param container If non-null, this is the parent view that the fragment's
-     * UI should be attached to.  The fragment should not add the view itself,
-     * but this can be used to generate the LayoutParams of the view.
+     * @param inflater           The LayoutInflater object that can be used to inflate
+     *                           any views in the fragment,
+     * @param container          If non-null, this is the parent view that the fragment's
+     *                           UI should be attached to.  The fragment should not add the view itself,
+     *                           but this can be used to generate the LayoutParams of the view.
      * @param savedInstanceState If non-null, this fragment is being re-constructed
-     * from a previous saved state as given here.
-     *
+     *                           from a previous saved state as given here.
      * @return view item fragment
      */
     @SuppressLint("SetTextI18n")
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_view_item, container, false);
-        tagRef = ((MainActivity) requireActivity()).getTagRef();
+        CollectionReference tagRef = ((MainActivity) requireActivity()).getTagRef();
         tagListener = tagRef.addSnapshotListener(this::setupTagListener);
+
         // Initialize TextViews
         TextView title = rootView.findViewById(R.id.view_item_title);
         TextView make = rootView.findViewById(R.id.view_item_make);
@@ -98,10 +94,10 @@ public class ViewItemFragment extends Fragment implements EditItemFragment.OnIte
         rootView.findViewById(R.id.edit_button).setOnClickListener(v -> {
             EditItemFragment editItemFragment = new EditItemFragment();
             Bundle args = new Bundle();
-            args.putParcelable("item",item);
-            args.putSerializable("listener",this);
+            args.putParcelable("item", item);
             editItemFragment.setArguments(args);
-            navigateToFragmentPage(getContext(),editItemFragment);
+            editItemFragment.setListener(this);
+            navigateToFragmentPage(getContext(), editItemFragment);
         });
 
         rootView.findViewById(R.id.delete_button).setOnClickListener(v -> {
@@ -132,7 +128,7 @@ public class ViewItemFragment extends Fragment implements EditItemFragment.OnIte
             Bundle tagArgs = new Bundle();
             tagArgs.putParcelableArrayList("itemList", selectedItem);
             applyTagFragment.setArguments(tagArgs);
-            applyTagFragment.show(requireActivity().getSupportFragmentManager(),"tagDialog");
+            applyTagFragment.show(requireActivity().getSupportFragmentManager(), "tagDialog");
         });
 
         return rootView;
@@ -150,6 +146,7 @@ public class ViewItemFragment extends Fragment implements EditItemFragment.OnIte
     /**
      * Whenever an item is updated (in Edit Item), this listener method adds the updated item
      * to View Item's bundle arguments and displays the updated item information upon view creation
+     *
      * @param updatedItem the Item with updated fields
      */
     @Override
@@ -162,8 +159,9 @@ public class ViewItemFragment extends Fragment implements EditItemFragment.OnIte
     /**
      * This method updates the tags with changes in the firestore database and creates new
      * tag objects
+     *
      * @param querySnapshots The updated information on the inventory from the database
-     * @param error Non-null if an error occurred in Firestore
+     * @param error          Non-null if an error occurred in Firestore
      */
     private void setupTagListener(QuerySnapshot querySnapshots, FirebaseFirestoreException error) {
         if (error != null) {
@@ -173,7 +171,7 @@ public class ViewItemFragment extends Fragment implements EditItemFragment.OnIte
         if (querySnapshots != null) {
             item.clearTags();
             chipGroup.removeAllViews();
-            for (QueryDocumentSnapshot doc: querySnapshots) {
+            for (QueryDocumentSnapshot doc : querySnapshots) {
                 Tag tag = new Tag(doc.getId(), doc.getData());
                 for (String id : tag.getItemIds()) {
                     if (Objects.equals(item.getId(), id)) item.addTag(tag);
@@ -188,18 +186,14 @@ public class ViewItemFragment extends Fragment implements EditItemFragment.OnIte
      */
     private void addTagsToChipGroup() {
         CollectionReference tagRef = ((MainActivity) requireActivity()).getTagRef();
-        for (Tag tag: item.getTags()) {
+        for (Tag tag : item.getTags()) {
             final Chip chip = FragmentUtils.makeChip(tag.getTagLabel(), true, chipGroup, getContext(), R.color.creme, R.color.black, R.color.black);
             final Tag finalTag = tag;
-            chip.setOnCloseIconClickListener(v -> {
-                tagRef.document(finalTag.getTagLabel()).get().addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        ArrayList<String> itemIds = new ArrayList<>((List<String>) task.getResult().get("items"));
-                        itemIds.removeIf(item -> item.equals(this.item.getId()));
-                        tagRef.document(finalTag.getTagLabel()).update("items", itemIds);
-                    }
-                });
-            });
+            chip.setOnCloseIconClickListener(v -> tagRef.document(finalTag.getTagLabel()).get().addOnSuccessListener(task -> {
+                ArrayList<String> itemIds = new ArrayList<>((List<String>) task.getData().get("items"));
+                itemIds.removeIf(item -> item.equals(this.item.getId()));
+                tagRef.document(finalTag.getTagLabel()).update("items", itemIds);
+            }));
         }
     }
 }


### PR DESCRIPTION
```
Caused by: java.io.NotSerializableException: com.google.android.material.chip.ChipGroup
```
Passing the ViewItemFragment as a bundled argument was causing it to try and bundle all of its variables, including things like ChipGroup which aren't parcelable. This was causing it to crash with the error above.